### PR TITLE
Fix syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "lib/timeout-transition-group.js",
   "peerDependencies": {
     "react": "0.14.x - 15.x",
-    "react-dom": "0.14.x - 15.x",
+    "react-dom": "0.14.x - 15.x"
   },
   "dependencies": {
     "global": "^4.3.0",


### PR DESCRIPTION
The trailing comma in `package.json` produces this error: 

```
npm ERR! addLocal Could not install [redacted]
npm ERR! Darwin 15.5.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.15
npm ERR! npm  v2.15.1
npm ERR! file /[redacted]/package.json
npm ERR! code EJSONPARSE

npm ERR! Failed to parse json
npm ERR! Trailing comma in object at 30:3
npm ERR!   },
npm ERR!   ^
npm ERR! File: /[redacted]/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR!
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! Please include the following file with any support request:
npm ERR!     /[redacted]/npm-debug.log
```